### PR TITLE
Use v0.0.1-alpha.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Use docker images with this tag
 # Effectively pins the demo to a specific release
-GIT_TAG=v0.0.1-alpha.1
+GIT_TAG=v0.0.1-alpha.2
 
 # Disk image filename
 IMAGE=kubevirt-demo.img


### PR DESCRIPTION
Works for me:

```
CentOS Linux 7 (Core)
Kernel 3.10.0-514.el7.x86_64 on an x86_64

kubevirt-demo login: root
[root@kubevirt-demo ~]# kubectl get pods
NAME                 READY     STATUS    RESTARTS   AGE
haproxy              1/1       Running   2          2m
libvirtd-4cj73       1/1       Running   1          2m
virt-api             1/1       Running   1          2m
virt-controller      1/1       Running   1          2m
virt-handler-4mb9d   1/1       Running   2          2m
[root@kubevirt-demo ~]# kubectl create -f /vm.json
vm "testvm" created
[root@kubevirt-demo ~]# virsh domstate testvm
running[fabiand@tee demo (master)]$ 
```