### PR TITLE
[WIP] Add minishift detection to demo

### DIFF
--- a/run-demo.sh
+++ b/run-demo.sh
@@ -32,12 +32,13 @@ check_kubectl() {
 }
 
 check_for_minikube() {
-  parn "Checking for minikube"
-  has_bin minikube || \
-    die "minikube not found. Please install minikube, see
+  parn "Checking for minikube/minishift"
+  (has_bin minikube; has_bin minishift) || \
+    die "Neither minikube nor minishift found. Please install minikube, see
 https://github.com/kubernetes/minikube for details."
   ( minikube status | grep -qsi stopped ) && \
-    die "minikube is installed but not started. Please start minikube."
+  ( minishift status | grep -qsu stopped ) && \
+    die "minikube/minishift is installed but not started. Please start minikube or minishift."
   ok
 }
 


### PR DESCRIPTION
As of minishift 1.7.0 it is also able to support KubeVirt. This change
adds detection to determine whether minishift is installed/running as an
alternative to minikube, and uses whichever is "up".

This currently does however make the assumption that if either is up then it is
the desired target for kubevirt AND what kubectl is configured to use. If both
are up, which is possible on the same system, then it will use whatever
installation kubectl is currently configured for.

This feels somewhat hacky, but still provides a workable way to use whichever
one is available to get started.