### PR TITLE
Update to v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ $ kubectl get vms -o yaml testvm
 
 ### Accessing VMs (serial console & spice)
 
+> **Note:** This is currently broken with v0.2.0
+
 > **Note:** This requires `kubectl` from Kubernetes 1.9 or later on the client
 
 A separate binary is provided to get quick access to the serial and graphical

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # KubeVirt Demo
 
 This demo will deploy [KubeVirt](https://www.kubevirt.io) on an existing
-[minikube](https://github.com/kubernetes/minikube/).
+[minikube](https://github.com/kubernetes/minikube/) with Kubernetes 1.9 or
+later.
 
 This has been tested on the following distributions:
 
@@ -18,7 +19,7 @@ This demo assumes that [minikube](https://github.com/kubernetes/minikube/) is up
 With minikube running, you can easily deploy KubeVirt:
 
 ```bash
-$ export VERSION=v0.1.0
+$ export VERSION=v0.2.0
 $ git clone https://github.com/kubevirt/demo.git
 $ cd demo
 $ kubectl create \
@@ -48,6 +49,8 @@ $ kubectl get vms -o yaml testvm
 
 ### Accessing VMs (serial console & spice)
 
+> **Note:** This requires `kubectl` from Kubernetes 1.9 or later on the client
+
 A separate binary is provided to get quick access to the serial and graphical
 ports of a VM. The tool is called `virtctl` and can be retrieved from the
 release page of KubeVirt:
@@ -60,22 +63,22 @@ $ curl -L -o virtctl \
 $ chmod a+x virtctl
 ```
 
-Once the tool is available you still need to expose the KubeVirt API service, in
-order to allow inbound access to the cluster:
-
-```
-# Expose access to the consoles via a service
-$ kubectl expose service --namespace kube-system virt-api --type=NodePort --name kubevirt-api
+We'll also use a proxy in order to ease the connection to the cluser:
+```bash
+# Use a proxy to avoid authentication hassles
+$ kubectl proxy --disable-filter=true &
+Starting to serve on 127.0.0.1:8001
+$ KUBEAPI=http://127.0.0.1:8001
 ```
 
 Now you are ready to connect to the VMs:
 
 ```
 # Connect to the serial console
-$ ./virtctl console -s $(minikube service --url -n kube-system kubevirt-api) testvm
+$ ./virtctl console -s $KUBEAPI testvm
 
 # Connect to the graphical display
-$ ./virtctl spice -s $(minikube service --url -n kube-system kubevirt-api) testvm
+$ ./virtctl spice -s $KUBEAPI testvm
 ```
 
 ## Next steps

--- a/manifests/vm.yaml
+++ b/manifests/vm.yaml
@@ -3,34 +3,20 @@ kind: VirtualMachine
 metadata:
   name: testvm
 spec:
+  terminationGracePeriodSeconds: 0
   domain:
+    resources:
+      requests:
+        memory: 64M
     devices:
-      graphics:
-      - type: spice
-      interfaces:
-      - type: network
-        source:
-          network: default
-      video:
-      - type: qxl
       disks:
-      - type: PersistentVolumeClaim
-        snapshot: external
-        device: disk
-        driver:
-          name: qemu
-          type: raw
-          cache: none
-        source:
-          name: disk-alpine
-        target:
+      - name: mydisk
+        volumeName: myvolume
+        disk:
           dev: vda
-      consoles:
-      - type: pty
-    memory:
-      unit: MB
-      value: 64
-    os:
-      type:
-        os: hvm
-    type: qemu
+  volumes:
+    - name: myvolume
+      iscsi:
+        iqn: iqn.2017-01.io.kubevirt:sn.42
+        lun: 2
+        targetPortal: iscsi-demo-target.default.svc.cluster.local


### PR DESCRIPTION
This change updates the demo to use KubeVirt v0.2.0

Major change affecting the demo is the removal of the HAProxy and the virtctl changes,

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>