### PR TITLE
README: Add note about remote-viewer/virt-viewer requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Now you are ready to connect to the VMs:
 $ ./virtctl console --kubeconfig ~/.kube/config testvm
 
 # Connect to the graphical display
+# Note: Requires `remote-viewer` from the `virt-viewer` package.
 $ ./virtctl vnc --kubeconfig ~/.kube/config testvm
 ```
 


### PR DESCRIPTION
VNC doesn't work unless the virt-viewer package is installed.