### PR TITLE
Devices is a struct and not a list.

### DIFF
--- a/manifests/vm.yaml
+++ b/manifests/vm.yaml
@@ -44,4 +44,4 @@ spec:
     resources:
       requests:
         memory: 64M
-    devices: []
+    devices: {}


### PR DESCRIPTION
If the validation webhook is enabled the manifests will fail if an array is used here.