### PR TITLE
manifests: Drop presets

### DIFF
--- a/manifests/vm.yaml
+++ b/manifests/vm.yaml
@@ -10,7 +10,6 @@ spec:
   template:
     metadata:
       labels: 
-        guest: testvm
         kubevirt.io/size: small
     spec:
       domain:
@@ -26,7 +25,9 @@ spec:
                 bus: virtio
           interfaces:
           - bridge: {}
-            name: default
+        resources:
+          requests:
+            memory: 64M
       networks:
       - name: default
         pod: {}
@@ -37,17 +38,4 @@ spec:
         - name: cloudinitvolume
           cloudInitNoCloud:
             userDataBase64: SGkuXG4= 
----
-apiVersion: kubevirt.io/v1alpha2
-kind: VirtualMachineInstancePreset
-metadata:
-  name: small
-spec:
-  selector:
-    matchLabels:
-      kubevirt.io/size: small
-  domain:
-    resources:
-      requests:
-        memory: 64M
     devices: {}

--- a/manifests/vm.yaml
+++ b/manifests/vm.yaml
@@ -24,7 +24,8 @@ spec:
               disk:
                 bus: virtio
           interfaces:
-          - bridge: {}
+          - name: default
+            bridge: {}
         resources:
           requests:
             memory: 64M

--- a/test.sh
+++ b/test.sh
@@ -33,8 +33,6 @@ k_wait_all_running() { bash ci/wait-pods-ok; }
   kubectl get vmis testvm -o yaml
   timeout_while 1m "kubectl get vmis testvm -o jsonpath='{.status.phase}' | grep Running"
 
-  kubectl get vmis testvm -o yaml | grep 'presets-applied'
-
   set +xe
 }
 


### PR DESCRIPTION
They can lead to issues, in order to make the demo flow more robust the preset was dropped.

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>