### PR TITLE
Adds a reference to oc client and needed SCCs before Kubvirt deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Loading cached images from config file.
 $ kubectl create configmap -n kube-system kubevirt-config --from-literal debug.useEmulation=true
 ```
 
+Deploying KubeVirt on `minishift`, you will need [to install openshift-client-tools and add the following SCCs](#running-on-okd-or-minishift) prior kubevirt.yaml deployment:
+
 Once it is runing KubeVirt can be deployed:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Loading cached images from config file.
 $ kubectl create configmap -n kube-system kubevirt-config --from-literal debug.useEmulation=true
 ```
 
-Deploying KubeVirt on `minishift`, you will need [to install openshift-client-tools and add the following SCCs](#running-on-okd-or-minishift) prior kubevirt.yaml deployment:
+> **Note:** When deploying KubeVirt on `minishift`, you will need [to install openshift-client-tools and add the following SCCs](#running-on-okd-or-minishift) prior kubevirt.yaml deployment.
 
 Once it is runing KubeVirt can be deployed:
 


### PR DESCRIPTION
When trying to follow the README for minishift, I got the
following error[1].
I was able to resolve it by simply applying the minishift
specific steps mentioned in the Appendix.

This patch merely adds a reference to those steps,
in case you follow the instructions by order.

[1] https://gist.github.com/nmagnezi/c502587fa01fabdf11eca07d437bd113