### PR TITLE
Transform demo vm yaml to new api version format

### DIFF
--- a/manifests/vm.yaml
+++ b/manifests/vm.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubevirt.io/v1alpha2
+apiVersion: kubevirt.io/v1alpha3
 kind: VirtualMachine
 metadata:
   name: testvm
@@ -13,14 +13,12 @@ spec:
       domain:
         devices:
           disks:
-            - name: containerdisk
-              volumeName: containervolume
-              disk:
-                bus: virtio
-            - name: cloudinitdisk
-              volumeName: cloudinitvolume
-              disk:
-                bus: virtio
+          - disk:
+              bus: virtio
+            name: containerdisk
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
           interfaces:
           - name: default
             bridge: {}
@@ -31,9 +29,9 @@ spec:
       - name: default
         pod: {}
       volumes:
-        - name: containervolume
+        - name: containerdisk
           containerDisk:
             image: kubevirt/cirros-registry-disk-demo
-        - name: cloudinitvolume
+        - name: cloudinitdisk
           cloudInitNoCloud:
             userDataBase64: SGkuXG4= 


### PR DESCRIPTION
The old api for volumes results in the following error when applied:

error: unable to recognize "vm.yaml": no matches for kind
"VirtualMachine" in version "kubevirt.io/v1alpha2"