### PR TITLE
Fix link to the user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ $ ./virtctl vnc testvm
 
 ### User Guide
 
-Now that KubeVirt is up an running, you can take a look at the [user guide](http://docs.kubevirt.io/) to understand how you can create and manage your own virtual machines.
+Now that KubeVirt is up an running, you can take a look at the [user guide](https://kubevirt.io/user-guide/docs/latest/welcome/index.html) to understand how you can create and manage your own virtual machines.
 
 ## Appendix
 


### PR DESCRIPTION
The link to the user guide was pointing to `docs.kubevirt.io` which does not actually contain the user guide (or anything).

Fixes #128
