### PR TITLE
bump kubevirt version to v0.34.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ $ minikube ssh -- test -e /dev/kvm \
 Now you are finally ready to deploy KubeVirt using our operator (comparable to an installer):
 
 ```bash
-$ kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/v0.28.0/kubevirt-operator.yaml
+$ kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/v0.34.2/kubevirt-operator.yaml
 …
 deployment.apps/virt-operator created
 
-$ kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/v0.28.0/kubevirt-cr.yaml
+$ kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/v0.34.2/kubevirt-cr.yaml
 kubevirt.kubevirt.io/kubevirt created
 ```
 
@@ -82,7 +82,7 @@ An additional binary is provided to get quick access to the serial and graphical
 The tool is called `virtctl` and can be retrieved from the release page of KubeVirt:
 
 ```bash
-$ curl -L -o virtctl https://github.com/kubevirt/kubevirt/releases/download/v0.28.0/virtctl-v0.28.0-linux-amd64
+$ curl -L -o virtctl https://github.com/kubevirt/kubevirt/releases/download/v0.34.2/virtctl-v0.34.2-linux-amd64
 $ chmod +x virtctl
 ```
 


### PR DESCRIPTION
While doing my onboarding I wanted to try the current version as well and went ahead to bump it here.
I also tried to figure out how to update the version used in the tests, but it's not being passed to the included scripts yet.

cc. @fabiand 
